### PR TITLE
chore: update the compile workflow

### DIFF
--- a/.github/workflows/zxc-code-compiles.yaml
+++ b/.github/workflows/zxc-code-compiles.yaml
@@ -12,6 +12,9 @@ on:
         type: string
         required: false
         default: "Code Compiles"
+  push:
+    branches:
+      - trunk-merge/**
 
 defaults:
   run:


### PR DESCRIPTION
This pull request makes a small update to the `.github/workflows/zxc-code-compiles.yaml` workflow file, adding a trigger for pushes to branches matching the `trunk-merge/**` pattern.