### PR TITLE
chore: Update required status names

### DIFF
--- a/.github/workflows/zxc-code-compiles.yaml
+++ b/.github/workflows/zxc-code-compiles.yaml
@@ -45,7 +45,7 @@ jobs:
       - name: Setup GoLang
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
-          go-version: ${{ inputs.go-version }}
+          go-version: ${{ inputs.go-version || '>=1.25.0' }}
 
       - name: Compile Code
         run: task build

--- a/.github/workflows/zxc-unit-test.yaml
+++ b/.github/workflows/zxc-unit-test.yaml
@@ -45,7 +45,7 @@ jobs:
       - name: Setup GoLang
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
-          go-version: ${{ inputs.go-version }}
+          go-version: ${{ inputs.go-version || '>=1.25.0' }}
 
       - name: Run Unit Tests
         run: task test:unit

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -1,5 +1,5 @@
 version: 0.1
 merge:
   required_status:
-    - "Build / Standard"
-    - "Unit Tests / Standard"
+    - "Code Compiles"
+    - "Unit Test"

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -1,5 +1,5 @@
 version: 0.1
 merge:
   required_status:
-    - Code Compiles
-    - Unit Test
+    - "Build / Standard"
+    - "Unit Tests / Standard"


### PR DESCRIPTION
This pull request updates the required status checks for merges in the `.trunk/trunk.yaml` configuration file. The change replaces the previous status checks with updated ones to better reflect the current build and test workflows.

Configuration update:

* Updated the `required_status` checks for merges to use "Build / Standard" and "Unit Tests / Standard" instead of "Code Compiles" and "Unit Test" in `.trunk/trunk.yaml`.