### PR TITLE
chore: Add merge-queue controller

### DIFF
--- a/.github/workflows/zxc-code-compiles.yaml
+++ b/.github/workflows/zxc-code-compiles.yaml
@@ -12,9 +12,6 @@ on:
         type: string
         required: false
         default: "Code Compiles"
-  push:
-    branches:
-      - trunk-merge/**
 
 defaults:
   run:

--- a/.github/workflows/zxc-unit-test.yaml
+++ b/.github/workflows/zxc-unit-test.yaml
@@ -12,9 +12,6 @@ on:
         type: string
         required: false
         default: "Unit Test"
-  push:
-    branches:
-      - trunk-merge/**
 
 defaults:
   run:

--- a/.github/workflows/zxf-merge-queue-controller.yaml
+++ b/.github/workflows/zxf-merge-queue-controller.yaml
@@ -16,15 +16,15 @@ concurrency:
 
 jobs:
   build:
-    name: "Merge Queue"
+    name: "Build"
     uses: ./.github/workflows/zxc-code-compiles.yaml
     with:
-      custom-job-label: "Build"
+      custom-job-label: "Merge Queue"
 
   unit-tests:
-    name: "Merge Queue"
+    name: "Unit Tests"
     uses: ./.github/workflows/zxc-unit-test.yaml
     needs:
       - build
     with:
-      custom-job-label: "Unit Tests"
+      custom-job-label: "Merge Queue"

--- a/.github/workflows/zxf-merge-queue-controller.yaml
+++ b/.github/workflows/zxf-merge-queue-controller.yaml
@@ -1,0 +1,30 @@
+name: "ZXF: Merge Queue Controller"
+on:
+  push:
+    branches:
+      - trunk-merge/**
+defaults:
+  run:
+    shell: bash
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pr-checks-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: "Merge Queue"
+    uses: ./.github/workflows/zxc-code-compiles.yaml
+    with:
+      custom-job-label: "Build"
+
+  unit-tests:
+    name: "Merge Queue"
+    uses: ./.github/workflows/zxc-unit-test.yaml
+    needs:
+      - build
+    with:
+      custom-job-label: "Unit Tests"

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -1,5 +1,5 @@
 version: 0.1
 merge:
   required_status:
-    - "Code Compiles"
-    - "Unit Test"
+    - "Merge Queue / Build"
+    - "Merge Queue / Unit Tests"

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -1,5 +1,5 @@
 version: 0.1
 merge:
-  required_status:
+  required_statuses:
     - "Build / Merge Queue"
     - "Unit Tests / Merge Queue"

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -1,5 +1,5 @@
 version: 0.1
 merge:
   required_status:
-    - "Merge Queue / Build"
-    - "Merge Queue / Unit Tests"
+    - "Build / Merge Queue"
+    - "Unit Tests / Merge Queue"


### PR DESCRIPTION
This pull request updates the CI workflow to introduce a new merge queue controller and aligns required status checks accordingly. It removes direct push triggers for the old workflows and ensures the merge process now relies on the new controller workflow.

**Merge Queue Controller Integration:**

* Added a new workflow file `zxf-merge-queue-controller.yaml` that triggers on pushes to `trunk-merge/**` and orchestrates the build and unit test jobs using the existing workflows, with custom job labels for clarity.

**Workflow Trigger Updates:**

* Removed the `push` trigger for `trunk-merge/**` from both `zxc-code-compiles.yaml` and `zxc-unit-test.yaml` to prevent them from running independently and ensure they are managed through the new controller. [[1]](diffhunk://#diff-27967245a97a8a29128fb6b78effef1a93934d79b3f4b838394993f006ce858cL15-L17) [[2]](diffhunk://#diff-16519657be7a7de47f7810334df1f22e9ab4ab0fe4f3f3bbe13bb61e73eea922L15-L17)

**Status Check Configuration:**

* Updated `.trunk/trunk.yaml` to require the new, more descriptive status checks ("Merge Queue / Build" and "Merge Queue / Unit Tests") instead of the previous generic ones.